### PR TITLE
titelprefix i fönster

### DIFF
--- a/src/hattmakarna/UI/LogInWindow.java
+++ b/src/hattmakarna/UI/LogInWindow.java
@@ -28,6 +28,8 @@ public class LogInWindow extends javax.swing.JFrame {
         
         txtEmail.addActionListener(e -> btnLogIn.doClick());
         pwdPassword.addActionListener(e -> btnLogIn.doClick());
+        
+        this.setTitle("Logga in");
     }
 
     /**

--- a/src/hattmakarna/UI/MainMenu.java
+++ b/src/hattmakarna/UI/MainMenu.java
@@ -34,6 +34,7 @@ public class MainMenu extends javax.swing.JFrame {
         } else {
             btnUsers.setVisible(false);
         }
+        this.setTitle("Huvudmeny");
     }
 
     /**

--- a/src/hattmakarna/data/Hattmakarna.java
+++ b/src/hattmakarna/data/Hattmakarna.java
@@ -75,6 +75,11 @@ public class Hattmakarna {
                 if (w instanceof JFrame jf) {
                     // instead of jf.setIconImage(icon);
                     jf.setIconImages(icons);
+                    
+                    //Sätter defaulttitel till "Hattmakarna - " + det som redan finns i de andra fönstrena
+                    String existingTitle = jf.getTitle();
+                    String title = existingTitle.isBlank() ? "Hattmakarna - " : "Hattmakarna - " + existingTitle;
+                    jf.setTitle(title);
                 }
                 if(w instanceof JDialog jd){
                     jd.setIconImages(icons);


### PR DESCRIPTION
Alla fönster har nu en titel som per default har titelprefix "Hattmakarna - " som man sen kan plussa på en ytterligare kort identifierare i de enskilda fönstrena med this.setTitle()

så this.setTitle("Ett fönster") kommer då att ge resultatet "Hattmakarna - Ett fönster